### PR TITLE
[fix] reroll function에서 user_id 반환을 누락 에러 해결

### DIFF
--- a/dist/frontFunc/frontFunc.Model/frontFunc.Model.ts
+++ b/dist/frontFunc/frontFunc.Model/frontFunc.Model.ts
@@ -64,13 +64,9 @@ export const frontRerollModel = async (
     try {
         await conn.beginTransaction();
 
-        console.log("front Reroll Model gender");
         const gender = await defineGender(user_id, conn);
-        console.log(gender);
 
-        console.log("front Reroll Model frontReroll func");
         const result = await frontReroll(gender, user_id, conn);
-        console.log(result);
 
         if (!result && result !== 0) {
             await conn.rollback();

--- a/dist/middlware/frontFunc.middleware.ts
+++ b/dist/middlware/frontFunc.middleware.ts
@@ -10,7 +10,7 @@ export const frontReroll = async (
 ): Promise<{ findUser: idealInfo } | number | null> => {
     try {
         const findIdleQuery = `
-            SELECT instagram_id
+            SELECT instagram_id, user_id
             FROM user
             WHERE gender = ?;
         `;
@@ -20,7 +20,7 @@ export const frontReroll = async (
         console.log("Found users count:", idleArray.length);
 
         if (idleArray.length === 0) {
-            return null; 
+            return null;
         }
 
         let idle_user: any;

--- a/dist/middlware/idleType.middleware.ts
+++ b/dist/middlware/idleType.middleware.ts
@@ -148,6 +148,7 @@ export const addFoundUserTable = async (
     VALUES (?, ?);
      `;
 
+     
     await conn.query<ResultSetHeader>(query, [my_id, idle_id]);
 };
 


### PR DESCRIPTION
### FIX
* FrontReroll 함수에서 instagram_id만 반환하게 되어 found_User에 user_id를 넣을 수 없는 문제 해결
* 쿼리문에서 user_id값을 가져오도록 수정